### PR TITLE
Fix: Standardize Tags Workflows (@sha to @v) 

### DIFF
--- a/.github/config/labels.json
+++ b/.github/config/labels.json
@@ -24,6 +24,7 @@
   { "name": "breaking-label", "color": "d93f0b", "description": "Breaking changes detected in body" },
   { "name": "merge-conflict", "color": "444444", "description": "PR has merge conflicts" },
 
+  { "name": "triage", "color": "ededed", "description": "Indicates an issue needs to be triaged" },
   { "name": "status: work-in-progress", "color": "f9d0c4", "description": "PR is still being worked on" },
   { "name": "status: ready-for-review", "color": "c2e0c6", "description": "PR is ready for human eyes" },
 


### PR DESCRIPTION
# 🚀 Description

## 🔗 Related Issues / Pull Requests

Closes: (#48)
Closes: (#50)


## 💡 Motivation and Context

## 🧪 Validation & Testing

- [X] Checked YAML syntax with `task lint`
- [X] Validated GitHub Workflows with `actionlint`
- [X] Tested Taskfile changes locally

## 📸 Screenshots (if appropriate)

## ✅ Contribution Checklist

- [X] **Conventional Commits:** My PR title follows the [specification](https://www.conventionalcommits.org/).
- [X] **Documentation:** I have updated the `docs/` folder (and translations if necessary).
- [X] **Automated Standards:** I have run `task lint` and all checks passed.
- [X] **SemVer:** I understand that this change will trigger a version bump based on my commit type.

## 📝 Additional Notes
